### PR TITLE
[c++] fixed File::contains for new objects

### DIFF
--- a/jar-extras/deps/ogss.common.cpp/ogss/internal/Pool.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/internal/Pool.h
@@ -113,7 +113,7 @@ template <class T> class Pool : public AbstractPool {
 
         T *rval = book->next();
         new (rval) T();
-        rval->id = -1;
+        rval->id = -1 - this->newObjects.size();
         this->newObjects.push_back(rval);
         return rval;
     };


### PR DESCRIPTION
This fix is necessary for [this line in `File::contains`](https://github.com/serialization/ogss/blob/master/jar-extras/deps/ogss.common.cpp/ogss/api/File.cpp#L225) to work:

```cpp
return ref == ((internal::Pool<Object> *)p)->newObjects.at(-1 - ID);
```

Without it, [this assertion in `File::free`](https://github.com/serialization/ogss/blob/master/jar-extras/deps/ogss.common.cpp/ogss/api/File.h#L202) fails when called on any but the first new object.