### PR TITLE
MarkAndSweep generator for C++

### DIFF
--- a/jar-extras/deps/ogss.common.cpp/ogss/api/AbstractMarkAndSweep.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/api/AbstractMarkAndSweep.h
@@ -1,0 +1,78 @@
+//
+// Created by Felix Krause on 29.04.20.
+//
+
+#ifndef OGSS_TEST_CPP_MARKANDSWEEPBASE_H
+
+#include <bitset>
+
+#include "../api/File.h"
+#include "../api/Object.h"
+#include "../internal/Pool.h"
+#include "../iterators/AllObjectIterator.h"
+
+namespace ogss {
+namespace api {
+
+/**
+ * General implementation of Mark-and-Sweep on objects of a File.
+ * An implementation for the types of a spec can be generated with
+ * -Ocpp:markAndSweep=true.
+ *
+ * During the lifetime of this object, objects in the file may not be created,
+ * removed, or modified. The generated implementation cannot handle NamedObjs
+ * and will fail if it encounters any.
+ */
+class AbstractMarkAndSweep {
+    api::File *file;
+    std::unordered_set<api::Object*> seen;
+
+    std::size_t neededBuckets() {
+        // re-hashing is expensive so we determine the total number of objects.
+        size_t count = 0;
+        for (auto *pool : *file) {
+            if (pool->super == nullptr) count += pool->size();
+        }
+        return count + 1; // accommodate for float rounding errors
+    }
+  protected:
+    explicit AbstractMarkAndSweep(api::File *file):
+            file(file), seen(neededBuckets()) {
+        seen.max_load_factor(1.0);
+    }
+
+    /**
+     * an implementation must call mark() on all objects in non-auto fields
+     * of the object.
+     */
+    virtual void markReferenced(api::Object *obj) =0;
+  public:
+    /**
+     * Marks the given object and everything it references.
+     */
+    void mark(api::Object *obj) {
+        if (obj == nullptr || obj->isDeleted() || seen.count(obj) > 0) return;
+        seen.insert(obj);
+        markReferenced(obj);
+    }
+
+    /**
+     * Frees all unmarked objects.
+     * Caution: Calling this without calling mark() will delete everything!
+     */
+    void sweep() {
+        for (auto *pool : *file) {
+            if (pool->super != nullptr) continue;
+            auto it = pool->allObjects();
+            while (it->hasNext()) {
+                auto *obj = it->next();
+                if (seen.count(obj) == 0) file->free(obj);
+            }
+        }
+    }
+};
+
+} // namespace internal
+} // namespace ogss
+
+#endif // OGSS_TEST_CPP_MARKANDSWEEPBASE_H

--- a/jar-extras/deps/ogss.common.cpp/ogss/api/Arrays.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/api/Arrays.h
@@ -52,6 +52,7 @@ namespace ogss {
 
             Array() : std::vector<T>() {}
             Array(std::initializer_list<T> init) : std::vector<T>(init) {}
+            Array(const Array &other) : std::vector<T>(other) {}
 
             virtual ~Array() {}
 

--- a/jar-extras/deps/ogss.common.cpp/ogss/api/Maps.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/api/Maps.h
@@ -131,6 +131,7 @@ namespace ogss {
             Map() : std::unordered_map<K, V>() {}
             Map(std::initializer_list<value_type> init) :
                 std::unordered_map<K, V>(init) {}
+            Map(const Map &other) : std::unordered_map<K, V>(other) {}
 
             virtual ~Map() {}
 

--- a/jar-extras/deps/ogss.common.cpp/ogss/api/Sets.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/api/Sets.h
@@ -74,6 +74,7 @@ namespace ogss {
             Set() : std::unordered_set<T>() {}
             Set(std::initializer_list<value_type> init) :
                 std::unordered_set<T>(init) {}
+            Set(const Set &other) : std::unordered_set<T>(other) {}
 
             virtual ~Set() {};
 

--- a/src/main/scala/ogss/backend/cpp/AbstractBackEnd.scala
+++ b/src/main/scala/ogss/backend/cpp/AbstractBackEnd.scala
@@ -85,6 +85,11 @@ trait AbstractBackEnd extends BackEnd {
   protected var cmakeNoWarn = false;
 
   /**
+   * If set to true, will generate a MarkAndSweep class
+   */
+  protected var generateMarkAndSweep = false;
+
+  /**
    * If interfaceChecks then skillName -> Name of sub-interfaces
    * @note the same interface can be sub and super, iff the type is a base type;
    * in that case, super wins!

--- a/src/main/scala/ogss/backend/cpp/Main.scala
+++ b/src/main/scala/ogss/backend/cpp/Main.scala
@@ -46,6 +46,7 @@ final class Main extends AbstractBackEnd
   with StringKeeperMaker
   with PoolsMaker
   with TypesMaker
+  with MarkAndSweepMaker
   //@note this maker has to be performed after others
   with FileNamesMaker {
 
@@ -130,6 +131,7 @@ final class Main extends AbstractBackEnd
       case "writefilenames"   ⇒ writeGeneratedSources = ("true".equals(value))
       case "pic"              ⇒ cmakeFPIC = ("true".equals(value))
       case "suppresswarnings" ⇒ cmakeNoWarn = ("true".equals(value))
+      case "markandsweep"     ⇒ generateMarkAndSweep = ("true".equals(value))
       case unknown            ⇒ sys.error(s"unkown Argument: $unknown")
     }
   }
@@ -139,7 +141,8 @@ final class Main extends AbstractBackEnd
     OptionDescription("interfaceChecks", "true/false", "if set to true, the generated API will contain is[[interface]] methods"),
     OptionDescription("writeFileNames", "true/false", "if set to true, create generatedFiles.txt that contains all generated file names"),
     OptionDescription("PIC", "true/false", "generated cmake project will create position independent code"),
-    OptionDescription("suppressWarnings", "true/false", "generated cmake project will tell gcc to suppress warnings")
+    OptionDescription("suppressWarnings", "true/false", "generated cmake project will tell gcc to suppress warnings"),
+    OptionDescription("markAndSweep", "true/false", "if set to true, a class implementing Mark-and-Sweep will be generated")
   )
 
   override def customFieldManual : String = """

--- a/src/main/scala/ogss/backend/cpp/MarkAndSweepMaker.scala
+++ b/src/main/scala/ogss/backend/cpp/MarkAndSweepMaker.scala
@@ -1,0 +1,128 @@
+package ogss.backend.cpp
+
+import ogss.oil.{ClassDef, InterfaceDef, MapType, SeqType, Type}
+
+import scala.collection.mutable
+
+trait MarkAndSweepMaker extends AbstractBackEnd {
+  case class TypeMarkImpl(name: String, argsAndImpl: String)
+
+  abstract override def make {
+    super.make
+    if (!generateMarkAndSweep) return
+    makeHeader
+    makeSource
+  }
+
+  private def makeHeader {
+    val out = files.open("MarkAndSweep.h")
+    out.write(s"""${beginGuard("MARK_AND_SWEEP")}
+#include <ogss/api/AbstractMarkAndSweep.h>
+
+${packageParts.mkString("namespace ", " {\nnamespace ", " {")}
+    namespace api {
+        class MarkAndSweep final : public ::ogss::api::AbstractMarkAndSweep {
+          protected:
+            void markReferenced(::ogss::api::Object *obj) final;
+          public:
+            explicit MarkAndSweep(::ogss::api::File *file):
+                    ::ogss::api::AbstractMarkAndSweep(file) {}
+        };
+    }
+${packageParts.map(_ ⇒ "}").mkString}
+$endGuard""")
+    out.close()
+  }
+
+  private def makeSource {
+    val markImpls = mutable.Map[ClassDef, TypeMarkImpl]()
+    for (c ← IR) {
+      val impl = genClassMarker(c)
+      if (impl != null) markImpls += (c -> impl)
+    }
+
+    val out = files.open("MarkAndSweep.cpp")
+    out.write(
+      s"""
+#include "MarkAndSweep.h"
+#include "File.h"
+
+${packageParts.mkString("namespace ", " {\nnamespace ", " {")}
+
+${markImpls.map(m ⇒s"""
+static inline void ${m._2.name}${m._2.argsAndImpl}""").mkString}
+
+void api::MarkAndSweep::markReferenced(::ogss::api::Object *obj) {
+    switch (obj->stid()) {
+        case -1: throw std::logic_error("MarkAndSweep not implemented on NamedObj!");${IR.map(t ⇒ {
+          val typeName = packageName + "::" + name(t)
+          s"""
+        case $typeName::typeID: ${callAllFields(t, typeName, markImpls)}"""
+        }).mkString}
+    }
+}
+${packageParts.map(_ ⇒ "}").mkString}
+""")
+    out.close()
+  }
+
+  private def callAllFields(t : ClassDef, typeName : String, markers: mutable.Map[ClassDef, TypeMarkImpl]) = {
+    // Set ensures that we don't get double classes
+    // if multiple interfaces have the same base type
+    val ret = mutable.Set[ClassDef]()
+    recIncludeAncestors(ret, t)
+    val calls = ret.map(c ⇒ {
+      markers.get(c) match {
+        case Some(m) ⇒
+          s"""
+            ${m.name}(*this, v);"""
+        case None ⇒ ""
+      }
+    }).mkString
+    if (calls.isEmpty) "break;" else
+      s"""{
+            auto *v = static_cast<$typeName*>(obj);$calls
+            break;
+        }"""
+  }
+
+  private def recIncludeAncestors(s : mutable.Set[ClassDef], i : InterfaceDef): Unit = {
+    if (i.superType != null) recIncludeAncestors(s, i.superType)
+    i.superInterfaces.foreach(i ⇒ recIncludeAncestors(s, i))
+  }
+
+  private def recIncludeAncestors(s : mutable.Set[ClassDef], t : ClassDef): Unit = {
+    s += t
+    if (t.superType != null) recIncludeAncestors(s, t.superType)
+    t.superInterfaces.foreach(i ⇒ recIncludeAncestors(s, i))
+  }
+
+  private def genClassMarker(t : ClassDef) = {
+    val actions = t.fields.map(f ⇒
+      if (f.isTransient || f.isDeleted) "" else processValue(f.`type`, s"v->${getter(f)}()")
+    ).mkString
+    if (actions.isEmpty) null else TypeMarkImpl(s"mark_${name(t)}_fields",
+      s"(api::MarkAndSweep &m, $packageName::${name(t)}* v){$actions\n}\n")
+  }
+
+  private def processValue(t : Type, v : String): String = {
+    t match {
+      case _ : ClassDef ⇒
+        s"""
+    m.mark($v);"""
+      case s : SeqType ⇒
+        val inner = processValue(s.baseType, "item")
+        if (inner.isEmpty) "" else s"""
+    if ($v != nullptr) for (auto *item : *$v) {$inner
+    }"""
+      case m : MapType ⇒
+        val innerK = processValue(m.keyType, "kv.first")
+        val innerV = processValue(m.valueType, "kv.second")
+        if (innerK.isEmpty && innerV.isEmpty) "" else
+          s"""
+    if ($v != nullptr) for (auto &kv : *$v) {$innerK$innerV
+    }"""
+      case _ ⇒ ""
+    }
+  }
+}

--- a/src/main/scala/ogss/backend/cpp/TypesMaker.scala
+++ b/src/main/scala/ogss/backend/cpp/TypesMaker.scala
@@ -239,7 +239,8 @@ ${packageParts.mkString("namespace ", " {\nnamespace ", " {")}
 
         out.write(s"""
 
-        ::ogss::TypeID stid() const override { return ${t.stid}; }
+        static constexpr ::ogss::TypeID typeID = ${t.stid};
+        ::ogss::TypeID stid() const override { return typeID; }
     };
 
     class ${name(t)}_UnknownSubType : public ${name(t)}, public ::ogss::api::NamedObj {


### PR DESCRIPTION
Adds C++ backend option to generate a mark-and-sweep implementation on `File`.

 * Non-invasive (does not touch objects during `mark()`)
 * Requires user to tell it what to mark since there is no root node
 * Currently cannot handle `NamedObj`s

As prerequisite, adds publicly queryable static `typeID` field to types (I also use that in my code).

Adds copy constructors to containers because I don't want to create another PR for just that.