### PR TITLE
[c++] made it compile & work on Windows

### DIFF
--- a/jar-extras/deps/ogss.common.cpp/ogss/internal/Book.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/internal/Book.h
@@ -40,7 +40,7 @@ template <class T> class Book {
     explicit Book(ObjectID expectedSize = defaultPageSize) :
       freelist(),
       pages(),
-      currentPage(expectedSize ? (T *)std::calloc(expectedSize, sizeof(T))
+      currentPage(expectedSize ? (T *)std::calloc(static_cast<size_t>(expectedSize), sizeof(T))
                                : nullptr),
       currentPageRemaining(0) {
         if (currentPage)

--- a/jar-extras/deps/ogss.common.cpp/ogss/internal/EnumPool.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/internal/EnumPool.h
@@ -56,7 +56,7 @@ class AbstractEnumPool : public fieldTypes::FieldType {
 class Creator;
 class Writer;
 
-template <typename T> class EnumPool : public AbstractEnumPool {
+template <typename T> class EnumPool final: public AbstractEnumPool {
     /**
      * values as seen from the combined specification
      */

--- a/jar-extras/deps/ogss.common.cpp/ogss/internal/Pool.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/internal/Pool.h
@@ -51,7 +51,7 @@ template <class T> class Pool : public AbstractPool {
         if (super) {
             this->data = (T **)((Pool<T> *)this->base)->data;
         } else {
-            this->data = new T *[this->cachedSize];
+            this->data = new T *[static_cast<size_t>(this->cachedSize)];
         }
     }
 
@@ -60,7 +60,7 @@ template <class T> class Pool : public AbstractPool {
         data = (T **)d;
 
         // update structural knowledge of data
-        staticDataInstances += newObjects.size() - deletedCount;
+        staticDataInstances += static_cast<ObjectID>(newObjects.size()) - deletedCount;
         deletedCount = 0;
         newObjects.clear();
     }
@@ -94,7 +94,7 @@ template <class T> class Pool : public AbstractPool {
       book(nullptr),
       newObjects() {}
 
-    virtual ~Pool() {
+    virtual ~Pool() override {
         if (book)
             delete book;
         if (!super)
@@ -113,7 +113,7 @@ template <class T> class Pool : public AbstractPool {
 
         T *rval = book->next();
         new (rval) T();
-        rval->id = -1 - this->newObjects.size();
+        rval->id = -1 - static_cast<ObjectID>(this->newObjects.size());
         this->newObjects.push_back(rval);
         return rval;
     };

--- a/jar-extras/deps/ogss.common.cpp/ogss/internal/SeqParser.cpp
+++ b/jar-extras/deps/ogss.common.cpp/ogss/internal/SeqParser.cpp
@@ -2,6 +2,8 @@
 // Created by Timm Felden on 03.04.19.
 //
 
+#include <algorithm>
+
 #include "SeqParser.h"
 #include "../concurrent/Pool.h"
 #include "../fieldTypes/ContainerType.h"

--- a/jar-extras/deps/ogss.common.cpp/ogss/iterators/AllObjectIterator.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/iterators/AllObjectIterator.h
@@ -19,6 +19,7 @@ namespace ogss {
          */
         struct AllObjectIterator :
                 public std::iterator<std::input_iterator_tag, api::Object *> {
+            virtual ~AllObjectIterator() =default;
 
             virtual AllObjectIterator &operator++() = 0;
 
@@ -49,6 +50,7 @@ namespace ogss {
 
         public:
             Implementation() : iter() {}
+            virtual ~Implementation() =default;
 
             explicit Implementation(const Pool<T> *p) : iter(p) {}
 

--- a/jar-extras/deps/ogss.common.cpp/ogss/iterators/DynamicDataIterator.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/iterators/DynamicDataIterator.h
@@ -41,6 +41,15 @@ class DynamicDataIterator : public std::iterator<std::input_iterator_tag, T> {
             p = nullptr;
     }
 
+    inline const Pool<T>* asPool() const {
+        return static_cast<const Pool<T> *>(p);
+    }
+
+    /** converts index to type expected by indexing. makes compiler happy. */
+    inline typename std::vector<T*>::size_type vIndex() const {
+        return static_cast<typename std::vector<T*>::size_type>(index);
+    }
+
   public:
     //! creates an empty iterator
     DynamicDataIterator() :
@@ -61,7 +70,7 @@ class DynamicDataIterator : public std::iterator<std::input_iterator_tag, T> {
         if ((index == last) | (nullptr == p->data)) {
             second = true;
             while (this->p) {
-                if ((last = ((Pool<T> *)this->p)->newObjects.size())) {
+                if ((last = static_cast<ObjectID>(asPool()->newObjects.size()))) {
                     index = 0;
                     break;
                 }
@@ -85,7 +94,7 @@ class DynamicDataIterator : public std::iterator<std::input_iterator_tag, T> {
                 second = true;
             }
             while (this->p) {
-                if ((last = ((Pool<T> *)this->p)->newObjects.size())) {
+                if ((last = static_cast<ObjectID>(asPool()->newObjects.size()))) {
                     index = 0;
                     break;
                 }
@@ -103,8 +112,8 @@ class DynamicDataIterator : public std::iterator<std::input_iterator_tag, T> {
 
     //! move to next position and return current element
     T *next() {
-        auto r = second ? ((Pool<T> *)p)->newObjects[index]
-                        : ((Pool<T> *)p)->data[index];
+        auto r = second ? asPool()->newObjects[vIndex()]
+                        : asPool()->data[vIndex()];
         this->operator++();
         return r;
     }
@@ -130,13 +139,13 @@ class DynamicDataIterator : public std::iterator<std::input_iterator_tag, T> {
 
     T &operator*() const {
         // @note increment happens before access, because we shifted data by 1
-        return *(second ? ((Pool<T> *)p)->newObjects[index]
-                        : ((Pool<T> *)p)->data[index]);
+        return *(second ? asPool()->newObjects[vIndex()]
+                        : asPool()->data[vIndex()]);
     }
 
     T *operator->() const {
-        return second ? ((Pool<T> *)p)->newObjects[index]
-                      : ((Pool<T> *)p)->data[index];
+        return second ? asPool()->newObjects[vIndex()]
+                        : asPool()->data[vIndex()];
     }
 
     //! iterators themselves can be used in generalized for loops

--- a/jar-extras/deps/ogss.common.cpp/ogss/iterators/StaticDataIterator.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/iterators/StaticDataIterator.h
@@ -34,6 +34,10 @@ namespace ogss {
 
             bool second;
 
+            /** converts index to type expected by indexing. makes compiler happy. */
+            inline typename std::vector<T*>::size_type vIndex() const {
+                return static_cast<typename std::vector<T*>::size_type>(index);
+            }
         public:
             //! creates an empty iterator
             StaticDataIterator()
@@ -46,7 +50,7 @@ namespace ogss {
                 if ((index == last) | (nullptr == p->data)) {
                     second = true;
                     index = 0;
-                    last = p->newObjects.size();
+                    last = static_cast<ObjectID>(p->newObjects.size());
                 }
             }
 
@@ -58,7 +62,7 @@ namespace ogss {
                     if (!second) {
                         second = true;
                         index = 0;
-                        last = p->newObjects.size();
+                        last = static_cast<ObjectID>(p->newObjects.size());
                     }
                 }
                 return *this;
@@ -72,12 +76,12 @@ namespace ogss {
 
             //! move to next position and return current element
             T *next() {
-                auto r = second ? p->newObjects[index] : p->data[index];
+                auto r = second ? p->newObjects[vIndex()] : p->data[vIndex()];
                 if (++index == last) {
                     if (!second) {
                         second = true;
                         index = 0;
-                        last = p->newObjects.size();
+                        last = static_cast<ObjectID>(p->newObjects.size());
                     }
                 }
                 return r;
@@ -108,11 +112,11 @@ namespace ogss {
 
             T &operator*() const {
                 // @note increment happens before access, because we shifted data by 1
-                return *(second ? p->newObjects[index] : p->data[index]);
+                return *(second ? p->newObjects[vIndex()] : p->data[vIndex()]);
             }
 
             T *operator->() const {
-                return second ? p->newObjects[index] : p->data[index];
+                return second ? p->newObjects[vIndex()] : p->data[vIndex()];
             }
 
             //!iterators themselves can be used in generalized for loops

--- a/jar-extras/deps/ogss.common.cpp/ogss/iterators/TypeOrderIterator.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/iterators/TypeOrderIterator.h
@@ -39,7 +39,7 @@ namespace ogss {
             TypeOrderIterator(const Pool<T> *p)
                     : ts(p), is(p) {
                 while (ts.hasNext()) {
-                    auto t = (Pool<T> *) ts.next();
+                    auto t = static_cast<const Pool<T> *>(ts.next());
                     if (t->staticSize()) {
                         new(&is) StaticDataIterator<T>(t);
                         return;
@@ -57,7 +57,7 @@ namespace ogss {
                 is.next();
                 if (!is.hasNext()) {
                     while (ts.hasNext()) {
-                        auto t = (Pool<T> *) ts.next();
+                        auto t = static_cast<const Pool<T> *>(ts.next());
                         if (t->staticSize()) {
                             new(&is) StaticDataIterator<T>(t);
                             break;
@@ -78,7 +78,7 @@ namespace ogss {
                 T *result = is.next();
                 if (!is.hasNext()) {
                     while (ts.hasNext()) {
-                        auto t = (Pool<T> *) ts.next();
+                        auto t = static_cast<const Pool<T> *>(ts.next());
                         if (t->staticSize()) {
                             new(&is) StaticDataIterator<T>(t);
                             break;

--- a/jar-extras/deps/ogss.common.cpp/ogss/streams/BufferedOutStream.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/streams/BufferedOutStream.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <cstring>
 #include <vector>
+#include <stdexcept>
 
 namespace ogss {
 namespace streams {

--- a/jar-extras/deps/ogss.common.cpp/ogss/streams/FileInputStream.cpp
+++ b/jar-extras/deps/ogss.common.cpp/ogss/streams/FileInputStream.cpp
@@ -2,20 +2,55 @@
 // Created by feldentm on 03.11.15.
 //
 
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <sys/stat.h>
 #include <sys/mman.h>
+#endif
 #include "FileInputStream.h"
 
 using namespace ogss::streams;
 
-
+#ifdef _WIN32
+FileInputStream::FileInputStream(void *begin, void *end, const std::string *path,
+                void *file, void *mapping):
+                InStream(begin, end), path(path), file(file), mapping(mapping) {
+}
+#else
 FileInputStream::FileInputStream(void *begin, void *end, const std::string* path, const FILE *file)
         : InStream(begin, end), path(path), file(file) {
 }
+#endif
 
 
 FileInputStream::FileInputStream(const std::string& path)
         : InStream(nullptr, nullptr), path(new std::string(path)), file(nullptr) {
+#ifdef _WIN32
+    mapping = nullptr;
+
+    auto stream = ::CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (stream == INVALID_HANDLE_VALUE)
+        throw Exception(std::string("could not open file ") + path);
+    auto length = ::GetFileSize(stream, nullptr);
+    if (length <= 0) return;
+
+    auto mappedStream = ::CreateFileMappingA(stream, nullptr, PAGE_READONLY, 0, 0, nullptr);
+    if (mappedStream == INVALID_HANDLE_VALUE) {
+        ::CloseHandle(stream);
+        throw Exception(std::string("could not map file ") + path);
+    }
+    void *base = position = static_cast<uint8_t*>(::MapViewOfFile(mappedStream, FILE_MAP_READ, 0, 0, length));
+    void *end = position + length;
+
+    if (base == nullptr) {
+        ::CloseHandle(stream);
+        ::CloseHandle(mappedStream);
+        throw Exception("Execution of MapViewOfFile failed.");
+    }
+    new(this) FileInputStream(base, end, this->path.get(), stream, mappedStream);
+#else
     FILE *stream = fopen(path.c_str(), "r");
 
     if (nullptr == stream)
@@ -42,13 +77,22 @@ FileInputStream::FileInputStream(const std::string& path)
 
     // set begin and end
     new(this) FileInputStream(base, end, this->path.get(), stream);
+#endif
 }
 
 FileInputStream::~FileInputStream() {
+#ifdef _WIN32
+    if (nullptr != file) {
+        ::UnmapViewOfFile(base);
+        ::CloseHandle(mapping);
+        ::CloseHandle(file);
+    }
+#else
     if (nullptr != file) {
         fclose((FILE *) file);
 
         if (nullptr != base)
             munmap(base, (size_t) end - (size_t) base);
     }
+#endif
 }

--- a/jar-extras/deps/ogss.common.cpp/ogss/streams/FileInputStream.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/streams/FileInputStream.h
@@ -25,12 +25,17 @@ namespace ogss {
             /**
              * the file object used for communication to the fs
              */
+#ifdef _WIN32
+            void *file, *mapping; // HANDLE
+            FileInputStream(void *begin, void *end, const std::string *path,
+                    void *file, void *mapping);
+#else
             const FILE *const file;
-
             /**
              * required for replacing begin and end after map
              */
-            FileInputStream(void *begin, void *end, const std::string *path, const FILE *file);
+            FileInputStream(void *begin, void *end, const std::string *path,const FILE *file);
+#endif
 
         public:
 

--- a/jar-extras/deps/ogss.common.cpp/ogss/streams/FileOutputStream.cpp
+++ b/jar-extras/deps/ogss.common.cpp/ogss/streams/FileOutputStream.cpp
@@ -5,15 +5,11 @@
 #include "FileOutputStream.h"
 #include "../api/Exception.h"
 #include "BufferedOutStream.h"
-#include <string.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 using namespace ogss::streams;
 
 FileOutputStream::FileOutputStream(const std::string &path) :
-  Stream(&buffer, (void *)(((long)&buffer) + BUFFER_SIZE)),
+  Stream(&buffer, static_cast<void*>(&buffer + BUFFER_SIZE)),
   path(path),
   file(fopen(path.c_str(), "w+")),
   bytesWriten(0) {

--- a/jar-extras/deps/ogss.common.cpp/ogss/streams/Stream.h
+++ b/jar-extras/deps/ogss.common.cpp/ogss/streams/Stream.h
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include <functional>
 
 namespace ogss {
     namespace streams {
@@ -55,11 +56,11 @@ namespace ogss {
             }
 
             inline bool eof() const noexcept {
-                return position >= end;
+                return std::greater_equal<void*>()(position, end);
             }
 
             inline bool has(size_t amountLeft) const noexcept {
-                return (position + amountLeft) < end;
+                return std::less<void*>()(position + amountLeft, end);
             }
         };
     }


### PR DESCRIPTION
Frag nicht, warum ich das gemacht habe; es hat etwas damit zu tun, dass ich mein Home Office wegen der Temperatur in den Keller verlegt habe, wo irgendwelche Interferenzen dazu führen, dass ich meinen Monitor nicht mit meinem DisplayPort-Kabel betreiben kann – aber das HDMI-Kabel funktioniert nur mit Windows… ich warte also auf ein neues DisplayPort-Kabel mit Ferritkernen und arbeite so lange auf Windows. Zum Inhalt:

Der Code lässt sich jetzt auf Windows mit MSVC+clang-cl kompilieren. clang-cl ist ein Drop-In für den MSVC-Compiler – Letzterer mag den Code absolut nicht. CLion unterstützt diese Toolchain; theoretisch müsste es sogar mit Visual Studio funktionieren, wenn man den Compiler entsprechend setzt; das habe ich aber nicht ausprobiert.

Semantische Änderungen waren:

 * Windows-spezifischer Code für `mmap`.
 * `long` nach `size_t`, weil `long` auf Win64 nur 32 bit hat.
 * `<` zwischen Pointern nach `std::less`, weil Ersteres nur eine partielle Ordnung hat, Letzteres eine totale. Analog `>=`.

Ansonsten mussten ein paar Header hin, die von der Windows C++ stdlib nicht implizit über andere Header importiert wurden. Die CMake-Datei hat auf Windows eine zusätzliche Compilation-Flag bekommen, um Exceptions einzuschalten, die in MSVC standardmäßig deaktiviert sind. Ein paar Casts hab ich hinzugefügt, um Berge von Warnungen loszuwerden, in denen die Fehlermeldungen untergingen.

Ich lade derzeit keine Dateien mit OGSS, also weiß ich nicht, ob das Laden tatsächlich funktioniert (und damit kann ich auch das Schreiben nicht verifizieren). Meine Änderungen reichen genau so weit, dass mein Code kompiliert und ich meine Tests ausführen kann. Sicher nicht funktionieren wird es, den Code in eine DLL zu kompilieren; die braucht diese unsäglichen `___dllimport` / `__dllexport` Dinger.